### PR TITLE
Potential fix for code scanning alert no. 1: Shell command built from environment values

### DIFF
--- a/app/scripts/esrp.js
+++ b/app/scripts/esrp.js
@@ -6,7 +6,7 @@
  **/
 
 const crypto = require('crypto');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const path = require('path');
 const os = require('os');
 const fs = require('fs');
@@ -218,7 +218,13 @@ function sign(esrpTool, op, pathToSign) {
   fs.writeFileSync(authJson, JSON.stringify(AUTH_JSON, undefined, 2));
 
   try {
-    execSync(`${esrpTool} Sign -l Verbose -a ${authJson} -p ${policyJson} -i ${signInputJson}`);
+    execFileSync(esrpTool, [
+      'Sign',
+      '-l', 'Verbose',
+      '-a', authJson,
+      '-p', policyJson,
+      '-i', signInputJson,
+    ]);
   } catch (e) {
     console.error('Failed to sign:', e);
     process.exit(e.status !== null ? e.status ?? 1 : 1);


### PR DESCRIPTION
Potential fix for [https://github.com/codeallthethingsbreak/headlamp/security/code-scanning/1](https://github.com/codeallthethingsbreak/headlamp/security/code-scanning/1)

To fix the issue, the dynamically constructed shell command should be replaced with a safer approach that avoids shell interpretation. Specifically, the `execSync` call should be replaced with `execFileSync`, which allows passing arguments as an array. This ensures that special characters in the input are treated as literal values and do not alter the command's behavior.

**Steps to implement the fix:**
1. Replace the `execSync` call on line 221 with `execFileSync`.
2. Pass the command (`Sign`) and its arguments (`-l Verbose`, `-a`, `authJson`, `-p`, `policyJson`, `-i`, `signInputJson`) as separate elements in an array.
3. Ensure that all paths (`authJson`, `policyJson`, `signInputJson`) are validated or sanitized before use.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
